### PR TITLE
cpu_input_boost: Remove boost check on display state

### DIFF
--- a/drivers/cpufreq/cpu_input_boost.c
+++ b/drivers/cpufreq/cpu_input_boost.c
@@ -342,7 +342,6 @@ static void cpu_ib_input_event(struct input_handle *handle, unsigned int type,
 	state = get_boost_state(b);
 
 	if (!(state & DRIVER_ENABLED) ||
-		!(state & !state_suspended) ||
 		(state & WAKE_BOOST) ||
 		(state & INPUT_REBOOST))
 		return;


### PR DESCRIPTION
This prevents boosting on display is off, so it will actually conflict with the
fingerprint boost, since that IRQ is sent when screen is off.